### PR TITLE
Improve equipment grid mod compatibility

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "SpidertronEngineer",
-    "version": "1.6.11",
+    "version": "1.6.12",
     "title": "Spidertron Engineer",
     "author": "Xorimuth",
     "description": "Build your factory as a Spidertron from the start! Instead of unlocking better weapons and armor, unlock upgrades to yourself.",

--- a/prototypes/equipment-grid.lua
+++ b/prototypes/equipment-grid.lua
@@ -21,10 +21,32 @@ equipment_grid5.width = 12
 equipment_grid5.height = 12
 
 if mods["bobvehicleequipment"] then
-    equipment_grid2.equipment_categories = {"armor", "spidertron", "vehicle", "armoured-vehicle"}
-    equipment_grid3.equipment_categories = {"armor", "spidertron", "vehicle", "armoured-vehicle"}
-    equipment_grid4.equipment_categories = {"armor", "spidertron", "vehicle", "armoured-vehicle"}
-    equipment_grid5.equipment_categories = {"armor", "spidertron", "vehicle", "armoured-vehicle"}
+    table.insert(equipment_grid2.equipment_categories, "vehicle-equipment")
+    table.insert(equipment_grid3.equipment_categories, "vehicle-equipment")
+    table.insert(equipment_grid4.equipment_categories, "vehicle-equipment")
+    table.insert(equipment_grid5.equipment_categories, "vehicle-equipment")
 end
+if mods["vtk-armor-plating"] then
+    table.insert(equipment_grid2.equipment_categories, "vtk-armor-plating")
+    table.insert(equipment_grid3.equipment_categories, "vtk-armor-plating")
+    table.insert(equipment_grid4.equipment_categories, "vtk-armor-plating")
+    table.insert(equipment_grid5.equipment_categories, "vtk-armor-plating")
+end
+if mods["Krastorio2"] then
+    table.insert(equipment_grid2.equipment_categories, "universal-equipment")
+    table.insert(equipment_grid2.equipment_categories, "vehicle-equipment")
+    table.insert(equipment_grid2.equipment_categories, "vehicle-motor")
 
+    table.insert(equipment_grid3.equipment_categories, "universal-equipment")
+    table.insert(equipment_grid3.equipment_categories, "vehicle-equipment")
+    table.insert(equipment_grid3.equipment_categories, "vehicle-motor")
+
+    table.insert(equipment_grid4.equipment_categories, "universal-equipment")
+    table.insert(equipment_grid4.equipment_categories, "vehicle-equipment")
+    table.insert(equipment_grid4.equipment_categories, "vehicle-motor")
+
+    table.insert(equipment_grid5.equipment_categories, "universal-equipment")
+    table.insert(equipment_grid5.equipment_categories, "vehicle-equipment")
+    table.insert(equipment_grid5.equipment_categories, "vehicle-motor")
+end
 data:extend{equipment_grid2, equipment_grid3, equipment_grid4, equipment_grid5}

--- a/prototypes/equipment-grid.lua
+++ b/prototypes/equipment-grid.lua
@@ -21,36 +21,26 @@ equipment_grid5.width = 12
 equipment_grid5.height = 12
 
 if mods["bobvehicleequipment"] then
-    table.insert(equipment_grid2.equipment_categories, "vehicle-equipment")
-    table.insert(equipment_grid3.equipment_categories, "vehicle-equipment")
-    table.insert(equipment_grid4.equipment_categories, "vehicle-equipment")
-    table.insert(equipment_grid5.equipment_categories, "vehicle-equipment")
+    equipment_grid2.equipment_categories = {"armor", "spidertron", "vehicle", "armoured-vehicle"}
+    equipment_grid3.equipment_categories = {"armor", "spidertron", "vehicle", "armoured-vehicle"}
+    equipment_grid4.equipment_categories = {"armor", "spidertron", "vehicle", "armoured-vehicle"}
+    equipment_grid5.equipment_categories = {"armor", "spidertron", "vehicle", "armoured-vehicle"}
 end
-if mods["vtk-armor-plating"] then
-    table.insert(equipment_grid2.equipment_categories, "vtk-armor-plating")
-    table.insert(equipment_grid3.equipment_categories, "vtk-armor-plating")
-    table.insert(equipment_grid4.equipment_categories, "vtk-armor-plating")
-    table.insert(equipment_grid5.equipment_categories, "vtk-armor-plating")
-end
+
 if mods["Krastorio2"] then
-    table.insert(equipment_grid2.equipment_categories, "universal-equipment")
-    table.insert(equipment_grid2.equipment_categories, "vehicle-equipment")
-    table.insert(equipment_grid2.equipment_categories, "vehicle-motor")
-    table.insert(equipment_grid2.equipment_categories, "robot-interaction-equipment")
+    local k2_grid_categories = {
+        "universal-equipment", 
+        "vehicle-equipment", 
+        "vehicle-motor", 
+        "robot-interaction-equipment"
+    }
 
-    table.insert(equipment_grid3.equipment_categories, "universal-equipment")
-    table.insert(equipment_grid3.equipment_categories, "vehicle-equipment")
-    table.insert(equipment_grid3.equipment_categories, "vehicle-motor")
-    table.insert(equipment_grid3.equipment_categories, "robot-interaction-equipment")
-
-    table.insert(equipment_grid4.equipment_categories, "universal-equipment")
-    table.insert(equipment_grid4.equipment_categories, "vehicle-equipment")
-    table.insert(equipment_grid4.equipment_categories, "vehicle-motor")
-    table.insert(equipment_grid4.equipment_categories, "robot-interaction-equipment")
-
-    table.insert(equipment_grid5.equipment_categories, "universal-equipment")
-    table.insert(equipment_grid5.equipment_categories, "vehicle-equipment")
-    table.insert(equipment_grid5.equipment_categories, "vehicle-motor")
-    table.insert(equipment_grid5.equipment_categories, "robot-interaction-equipment")
+    for _, v in ipairs(k2_grid_categories) do
+        table.insert(equipment_grid2.equipment_categories, v)
+        table.insert(equipment_grid3.equipment_categories, v)
+        table.insert(equipment_grid4.equipment_categories, v)
+        table.insert(equipment_grid5.equipment_categories, v)
+    end
+    
 end
 data:extend{equipment_grid2, equipment_grid3, equipment_grid4, equipment_grid5}

--- a/prototypes/equipment-grid.lua
+++ b/prototypes/equipment-grid.lua
@@ -36,17 +36,21 @@ if mods["Krastorio2"] then
     table.insert(equipment_grid2.equipment_categories, "universal-equipment")
     table.insert(equipment_grid2.equipment_categories, "vehicle-equipment")
     table.insert(equipment_grid2.equipment_categories, "vehicle-motor")
+    table.insert(equipment_grid2.equipment_categories, "robot-interaction-equipment")
 
     table.insert(equipment_grid3.equipment_categories, "universal-equipment")
     table.insert(equipment_grid3.equipment_categories, "vehicle-equipment")
     table.insert(equipment_grid3.equipment_categories, "vehicle-motor")
+    table.insert(equipment_grid3.equipment_categories, "robot-interaction-equipment")
 
     table.insert(equipment_grid4.equipment_categories, "universal-equipment")
     table.insert(equipment_grid4.equipment_categories, "vehicle-equipment")
     table.insert(equipment_grid4.equipment_categories, "vehicle-motor")
+    table.insert(equipment_grid4.equipment_categories, "robot-interaction-equipment")
 
     table.insert(equipment_grid5.equipment_categories, "universal-equipment")
     table.insert(equipment_grid5.equipment_categories, "vehicle-equipment")
     table.insert(equipment_grid5.equipment_categories, "vehicle-motor")
+    table.insert(equipment_grid5.equipment_categories, "robot-interaction-equipment")
 end
 data:extend{equipment_grid2, equipment_grid3, equipment_grid4, equipment_grid5}


### PR DESCRIPTION
Applied [suggestion from Glendening](https://mods.factorio.com/mod/SpidertronEngineer/discussion/5f81aaa86c91db28401e0848) to add more categories to the equipment grid and allow more modded vehicle parts to work inside spidertron.

I tested with Krastorio2.